### PR TITLE
Include stdio.h. It was sneaking in through png.h

### DIFF
--- a/src/value/UrlValue.cpp
+++ b/src/value/UrlValue.cpp
@@ -30,6 +30,7 @@
 #ifdef WITH_LIBJPEG
 #include <jpeglib.h>
 #include <setjmp.h>
+#include <stdio.h>
 
 struct urlvalue_jpeg_error_mgr {
   struct jpeg_error_mgr pub;	/* "public" fields */


### PR DESCRIPTION
If you ./configure --without-libpng then stdio.h was not getting
pulled in, but is required in the jpeg code. Ensure it comes in.
