### PR TITLE
[FIX] Allow whitespaces between a variable and a colon in a declaration

### DIFF
--- a/src/lessstylesheet/UnprocessedStatement.cpp
+++ b/src/lessstylesheet/UnprocessedStatement.cpp
@@ -197,6 +197,13 @@ bool UnprocessedStatement::processDeclaration (Declaration* declaration) {
 #endif
   
   getValue(declaration->getValue());
+
+  // fix: If there's a Token (not empty) and if this token is a space
+  if (declaration->getValue().empty() == false &&
+      declaration->getValue().front().type == Token::WHITESPACE) {
+    // Then we dismiss it to process the next token which should be a colon
+    declaration->getValue().pop_front();
+  }
   
   if (declaration->getValue().empty() ||
       declaration->getValue().front().type != Token::COLON) {


### PR DESCRIPTION
When writing something like below clessc compile perfectly the css.
```css
.foo
{
	bar: 1px;
}
```
But as soon as you put a space between ``bar`` and the ``colon`` like in this example:

```css
.foo
{
	bar : 1px;
}
```

The compiler returns this error

```
E0616 16:13:08.100565  8832 lessc.cpp:172] /home/XXX/Desktop/test.less: Line 2, Column 1 Parse Error: Found "bar : 1px" when expecting variable, mixin or declaration.
```

This pull request, is checking if there is a whitespace before the colon and dismiss it.

It is fixing one of the issues in here: https://github.com/BramvdKroef/clessc/issues/28